### PR TITLE
Change to recommended OSM tileserver and add attribution

### DIFF
--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -34,9 +34,9 @@
       // });
 
       const layer = L.tileLayer(
-        "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
         {
-          attribution: "",
+          attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
         }
       );
 


### PR DESCRIPTION
Switches Leaflet to use the recommended tileserver domain as described in the [OSMF tile usage policy](https://operations.osmfoundation.org/policies/tiles/).

Adds OSM attribution to the map - this is a requirement to use OSM data. Happy to chat further about why this is important :slightly_smiling_face: 